### PR TITLE
Adding token validation to get users endpoint

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -2,24 +2,25 @@ const express = require('express');
 const router = express.Router();
 const httpStatus = require('lib/httpStatus');
 const User = require('../models/User');
+const verifyToken = require('../lib/verifyToken');
 
 router.post('/', function (req, res) {
   User.create({
-      name : req.body.name,
-      email : req.body.email,
-      password : req.body.password
-    },
+    name: req.body.name,
+    email: req.body.email,
+    password: req.body.password
+  },
     function (err, user) {
       if (err) return res.status(httpStatus.INTERNAL_SERVER_ERROR).send(`Server error: ${err.message}`);
       res.status(httpStatus.OK).send(user);
     });
 });
 
-router.get('/', function (req, res) {
+router.get('/', verifyToken, function (req, res, next) {
   User.find({}, function (err, users) {
     if (err) return res.status(httpStatus.INTERNAL_SERVER_ERROR).send(`Server error: ${err.message}`);
     res.status(httpStatus.OK).send(users);
-  }).select('-password -__v').sort({name: 1});
+  }).select('-password -__v').sort({ name: 1 });
 });
 
 router.get('/:id', function (req, res) {
@@ -33,13 +34,14 @@ router.get('/:id', function (req, res) {
 router.delete('/:id', function (req, res) {
   User.findByIdAndRemove(req.params.id, function (err, user) {
     if (err) return res.status(httpStatus.INTERNAL_SERVER_ERROR).send(`Server error: ${err.message}`);
-    res.status(httpStatus.OK).send("User: "+ user.name +" was deleted.");
+    res.status(httpStatus.OK).send("User: " + user.name + " was deleted.");
   });
 });
 
 router.put('/:id', function (req, res) {
   User.findByIdAndUpdate(req.params.id, {
-    $set: { email: req.body.email, name: req.body.name }}, {new:false}, function (err, user) {
+    $set: { email: req.body.email, name: req.body.name }
+  }, { new: false }, function (err, user) {
     if (err) return res.status(httpStatus.INTERNAL_SERVER_ERROR).send(`Server error: ${err.message}`);
     res.status(httpStatus.NO_CONTENT).send(user);
   });


### PR DESCRIPTION
The [documentation](https://github.com/bobmacneal/node-api-jwt#users) implies that the get users method has token validation

>The three remaining endpoints in userController.js (e.g., get by id, update, and delete) do not require a JWT token, 

This method didn't have authentication.